### PR TITLE
Update to wgpu 0.20.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wgpu-async"
-version = "0.19.1"
+version = "0.20.1"
 edition = "2021"
 license = "MIT"
 description = "Converts some WGPU callback methods to async methods."
@@ -12,7 +12,7 @@ categories = ["asynchronous", "rendering"]
 include = ["/Cargo.toml", "/LICENSE", "/README.md", "/src/**"]
 
 [dependencies]
-wgpu = "0.19.1"
+wgpu = "0.20.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 pollster = "0.3"


### PR DESCRIPTION
Updated wgpu crate dependency to 0.20.1.

I'm aware that there's a newer version of wgpu already, but that contains some breaking changes (none apply here, as far as I could tell), and I'm tied to the 0.20.1 version due to other dependencies in my project for now :)